### PR TITLE
fix: allow scoped theme

### DIFF
--- a/themes/src/index.ts
+++ b/themes/src/index.ts
@@ -56,9 +56,7 @@ export function createThemes<
 
     themeClassNames[theme] = themeClassName;
 
-    themesString += `html[data-theme="${themeClassName}"] {\n${addTokens(
-      theme
-    )}}\n\n`;
+    themesString += `.${themeClassName} {\n${addTokens(theme)}}\n\n`;
   }
 
   const style = React.createElement(

--- a/themes/src/index.ts
+++ b/themes/src/index.ts
@@ -82,7 +82,11 @@ function setClassName(preferred) {
     const func = new Function(\`return ${cb.toString()}\`)
     const className = func()(preferred, ${JSON.stringify(themeClassNames)});
 
-    html.setAttribute("data-theme", className);
+    for (const className in ${JSON.stringify(themeClassNames)}) {
+        html.classList.remove(className);
+    }
+
+    html.classList.add(className);
 }
 
 mediaMatch.addEventListener("change", ({ matches }) => {


### PR DESCRIPTION
The current implementation only allows setting global themes once the CSS theme selector is using the `html` selector. However, I believe we could allow both global and scoped themes just by removing the stricter CSS selector. I think this was the original intention because the documentation also suggests you can use themes in certain parts of the application instead of global.

For example: 
```jsx
<div className={themes.dark}>Hello dark</div>
```